### PR TITLE
Merging non array values.

### DIFF
--- a/src/MtnMomoServiceProvider.php
+++ b/src/MtnMomoServiceProvider.php
@@ -91,7 +91,7 @@ class MtnMomoServiceProvider extends ServiceProvider
             'json' => [
                 'body',
             ],
-        ], $this->app['config']->get('mtn-momo.guzzle.options'));
+        ], (array) $this->app['config']->get('mtn-momo.guzzle.options'));
 
         return new Client($options);
     }


### PR DESCRIPTION
For some reason, ```php  $this->app['config']->get('mtn-momo.guzzle.options') ``` isn't converted to array before it's merged with default guzzle configures used to send request to server.

Casting It to array takes care of it.

More Info [Here](https://www.php.net/manual/en/function.array-merge.php#119355)
resolves #34 